### PR TITLE
Cart show action and cart accessibility

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,16 @@
 class ApplicationController < ActionController::Base
+
+  def current_cart
+    if session[:cart_id]
+      # check if there is an existing session for the cart
+      cart = Cart.find_by(id: session[:cart_id])
+      @current_cart = cart
+    else
+      # create a new cart if there is no cart session
+      # store the session cart_id
+      @current_cart = Cart.create
+      session[:cart_id] = @current_cart.id
+    end
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 class ApplicationController < ActionController::Base
 
+  before_action :current_cart
+
   def current_cart
     if session[:cart_id]
       # check if there is an existing session for the cart

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,2 +1,3 @@
 class CartsController < ApplicationController
+
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,3 +1,6 @@
 class CartsController < ApplicationController
 
+  def show
+    @cart = @current_cart
+  end
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -3,4 +3,5 @@ class CartsController < ApplicationController
   def show
     @cart = @current_cart
   end
+
 end

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -2,13 +2,13 @@
   <h2>Shopping Cart</h2>
   <table class="table">
     <thead>
-    <tr>
-      <th>Item</th>
-      <th>Price</th>
-      <th>Quantity</th>
-      <th>Total</th>
-      <th>Remove</th>
-    </tr>
+      <tr>
+        <th>Item</th>
+        <th>Price</th>
+        <th>Quantity</th>
+        <th>Total</th>
+        <th>Remove</th>
+      </tr>
     </thead>
     <tbody>
     </tbody>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -1,0 +1,17 @@
+<main>
+  <h2>Shopping Cart</h2>
+  <table class="table">
+    <thead>
+    <tr>
+      <th>Item</th>
+      <th>Price</th>
+      <th>Quantity</th>
+      <th>Total</th>
+      <th>Remove</th>
+    </tr>
+    </thead>
+    <tbody>
+    </tbody>
+  </table>
+
+</main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
   </head>
 
   <header>
+    <%= button_to "Cart", cart_path(session[:cart_id]), method: :get %>
     <% if session[:user_id] %>
       <%= button_to "Log out", logout_path, method: :delete %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
   get "/auth/:provider/callback", to: "users#create"
   delete "/logout", to: "users#destroy", as: "logout"
 
-
+  get 'carts/:id', to: "carts#show", as: "cart"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,18 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2020_11_17_023314) do
 
   # These are extensions that must be enabled in order to support this database

--- a/test/controllers/carts_controller_test.rb
+++ b/test/controllers/carts_controller_test.rb
@@ -5,20 +5,6 @@ describe CartsController do
   #   value(1+1).must_equal 2
   # end
 
-  # describe "show" do
-  #
-  #   it "will get show for current cart" do
-  #
-  #     get root_path
-  #
-  #     current_cart = Cart.create()
-  #     session[:cart_id] = cart.id
-  #
-  #
-  #
-  #   end
-  #
-  # end
   describe 'current cart' do
     it "creates a new cart when visiting the site for the first time" do
 
@@ -52,6 +38,24 @@ describe CartsController do
       # expect(current_cart.id).must_equal cart.id
 
     end
+  end
+
+  describe "show" do
+
+    it "will get show for current cart" do
+      # Arrange
+      get root_path
+      cart_id = session[:cart_id]
+      current_cart = Cart.find_by(id: cart_id)
+
+      # Act
+      get cart_path(cart_id)
+
+      # Assert
+      must_respond_with :success
+
+    end
+
   end
 
 end

--- a/test/controllers/carts_controller_test.rb
+++ b/test/controllers/carts_controller_test.rb
@@ -4,4 +4,54 @@ describe CartsController do
   # it "does a thing" do
   #   value(1+1).must_equal 2
   # end
+
+  # describe "show" do
+  #
+  #   it "will get show for current cart" do
+  #
+  #     get root_path
+  #
+  #     current_cart = Cart.create()
+  #     session[:cart_id] = cart.id
+  #
+  #
+  #
+  #   end
+  #
+  # end
+  describe 'current cart' do
+    it "creates a new cart when visiting the site for the first time" do
+
+      expect{
+        get root_path
+      }.must_differ "Cart.count", 1
+
+      cart_id = session[:cart_id]
+      current_cart = Cart.find_by(id: cart_id)
+
+      expect(current_cart).wont_be_nil
+      expect(session[:cart_id]).must_equal current_cart.id
+
+    end
+
+    it "should have the same cart throughout the site " do
+
+      get root_path
+      cart_id = session[:cart_id]
+      cart = Cart.find_by(id: cart_id)
+
+      # wait on other controllers to get another path and finish out writing test
+
+      # expect{
+      #   get user_path(users(:ada).id)
+      # }.wont_change "Cart.count"
+      # current_cart_id = session[:cart_id]
+      # current_cart = Cart.find_by(id: current_cart_id)
+      #
+      # expect(current_cart).wont_be_nil
+      # expect(current_cart.id).must_equal cart.id
+
+    end
+  end
+
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,10 +3,10 @@ ada:
   uid: 12345
   email: ada@adadev.org
   username: ada
-  avatar: https://placekitten.com/50/50
+  image: https://placekitten.com/50/50
 sophie:
   provider: github
   uid: 33333
   email: sophieemessing@gmail.com
   username: sophie
-  avatar: https://placekitten.com/50/50
+  image: https://placekitten.com/50/50


### PR DESCRIPTION
Used before action filter to invoke current cart method. Will ensure that a guest or user entering the site will have a cart ready for them to use or returning users or guests can access their same cart. I wrote some tests for this method and also added the show action method to the Cart controller.